### PR TITLE
Expand parameter list for python_package_lib

### DIFF
--- a/build_defs/python_external.bzl
+++ b/build_defs/python_external.bzl
@@ -15,7 +15,7 @@ def run_setup_py_impl(ctx):
                 'echo "[DONE] running setup.py"']
     ctx.action(
         inputs = ctx.files.dep,
-        command = '&&'.join(commands),
+        command = ' && '.join(commands),
         mnemonic = 'RunPySetup',
         outputs = [installed_files],
         use_default_shell_env = True

--- a/build_defs/python_external.bzl
+++ b/build_defs/python_external.bzl
@@ -30,7 +30,7 @@ run_setup_py = rule(
 )
 
 
-def python_package_lib(name, dep, visibility=None):
+def python_package_lib(name, dep, **kwargs):
     # Install the files into the current directory and save them into a file.
     run_setup_py(
         name = name + '_build_files',
@@ -56,7 +56,7 @@ def python_package_lib(name, dep, visibility=None):
     native.py_library(
         name = name,
         srcs = [':' + name + '_loader'],
-        visibility = visibility
+        **kwargs
     )
 
 


### PR DESCRIPTION
This allows us to define the `srcs_version` (and other things)
without having to manually add support for each one in.

You could probably do this for `python_package_bundle`, too,
but I haven't tested that.

Feel free to only take the first commit if you don't want the
second.
